### PR TITLE
Fix "arg" dependency for package

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@types/node": "^14.11.2",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
-    "arg": "^5.0.0",
     "babel-jest": "^26.6.3",
     "eslint": "^7.9.0",
     "eslint-config-prettier": "^6.11.0",
@@ -90,6 +89,7 @@
     "webpack-cli": "^4.5.0"
   },
   "dependencies": {
+    "arg": "^5.0.0",
     "chalk": "^4.1.0",
     "isomorphic-fetch": "^3.0.0",
     "it-all": "^1.0.5",


### PR DESCRIPTION
The published package command uses "arg", so it should be in the dependencies.

Error example:
```
~/ghq/github.com/tash-2s/rmrk-batch-samples main % yarn rmrk-tools-consolidate
yarn run v1.22.10
$ /Users/t/ghq/github.com/tash-2s/rmrk-batch-samples/node_modules/.bin/rmrk-tools-consolidate
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module 'arg'
Require stack:
- /Users/t/ghq/github.com/tash-2s/rmrk-batch-samples/node_modules/rmrk-tools/dist-cli/cli/consolidate.js
```

The issue was introduced in this PR. https://github.com/rmrk-team/rmrk-tools/pull/31