### PR TITLE
Update consolidate.ts error message when no path provided

### DIFF
--- a/cli/consolidate.ts
+++ b/cli/consolidate.ts
@@ -27,7 +27,7 @@ const consolidate = async () => {
   const file = args["--json"];
   const collectionFilter = args["--collection"];
   if (!file) {
-    console.error("File path must be provided");
+    console.error("File path must be provided through --json arg");
     process.exit(1);
   }
 


### PR DESCRIPTION
Currently when you run `rmrk-tools-consolidate` you get the error `File path must be provided` but doesn't specify the argument.  This file path must be passed through the --json arg.

Suggest updating console error message to `File path must be provided through --json arg`