### PR TITLE
Fix/fetch skipped blocks

### DIFF
--- a/cli/run-listener.ts
+++ b/cli/run-listener.ts
@@ -1,8 +1,29 @@
 #! /usr/bin/env node
-import { RemarkListener } from "../src/listener";
-import { getApi } from "../src/tools/utils";
+import { IStorageProvider, RemarkListener } from "../src/listener";
+import { getApi, getLatestFinalizedBlock } from "../src/tools/utils";
 import { Remark } from "../src/tools/consolidator/remark";
 import { Consolidator } from "../src";
+
+/**
+ * RMRK listener storage provider to save latest block
+ */
+class StorageProvider implements IStorageProvider {
+  readonly storageKey: string = "latestBlock";
+  public latestBlock = 0;
+
+  constructor(storageKey = "latestBlock", blockNum = 0) {
+    this.storageKey = storageKey;
+    this.latestBlock = blockNum;
+  }
+
+  public set = async (latestBlock: number) => {
+    this.latestBlock = latestBlock;
+  };
+
+  public get = async () => {
+    return this.latestBlock;
+  };
+}
 
 const runListener = async () => {
   const api = await getApi("wss://kusama-rpc.polkadot.io");
@@ -10,14 +31,18 @@ const runListener = async () => {
     const consolidator = new Consolidator();
     return await consolidator.consolidate(remarks);
   };
+  const latestBlock = await getLatestFinalizedBlock(api);
+  const storageProvider = new StorageProvider("latestBlock", latestBlock);
+
   const listener = new RemarkListener({
     polkadotApi: api,
-    prefixes: [],
+    prefixes: ["0x726d726b", "0x524d524b"],
     consolidateFunction,
+    storageProvider,
+    loggerEnabled: true,
   });
   const subscriber = listener.initialiseObservable();
   subscriber.subscribe((val) => console.log(val));
-
   const unfinilisedSubscriber = listener.initialiseObservableUnfinalised();
   unfinilisedSubscriber.subscribe((val) =>
     console.log("Unfinalised remarks:", val)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rmrk-tools",
-  "version": "1.0.40-rc.1",
+  "version": "1.0.40-rc.3",
   "description": "Suite of libraries implementing RMRK.app specs",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rmrk-tools",
-  "version": "1.0.38",
+  "version": "1.0.40-rc.1",
   "description": "Suite of libraries implementing RMRK.app specs",
   "repository": {
     "type": "git",

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -25,6 +25,7 @@ interface IProps {
   consolidateFunction: (remarks: Remark[]) => Promise<ConsolidatorReturnType>;
   storageProvider?: IStorageProvider;
   storageKey?: string;
+  loggerEnabled?: boolean;
 }
 
 export interface IStorageProvider {
@@ -61,6 +62,7 @@ export class RemarkListener {
   private missingBlockCallsFetched: boolean;
   private prefixes: string[];
   private currentBlockNum: number;
+  private loggerEnabled: boolean;
   public storageProvider: IStorageProvider;
   private consolidateFunction: (
     remarks: Remark[]
@@ -72,6 +74,7 @@ export class RemarkListener {
     consolidateFunction,
     storageProvider,
     storageKey,
+    loggerEnabled = false,
   }: IProps) {
     if (!polkadotApi) {
       throw new Error(
@@ -91,6 +94,7 @@ export class RemarkListener {
     this.consolidateFunction = consolidateFunction;
     this.storageProvider =
       storageProvider || new LocalStorageProvider(storageKey);
+    this.loggerEnabled = loggerEnabled;
   }
 
   private initialize = async () => {
@@ -105,6 +109,12 @@ export class RemarkListener {
       this.missingBlockCalls = await this.fetchMissingBlockCalls(latestBlock);
       this.missingBlockCallsFetched = true;
       this.consolidate();
+    }
+  };
+
+  private logger = (message: string) => {
+    if (this.loggerEnabled) {
+      console.log(message);
     }
   };
 
@@ -132,9 +142,18 @@ export class RemarkListener {
   /*
    Fetch blocks between last block in dump and last block on chain
    */
-  public async fetchMissingBlockCalls(latestBlock: number): Promise<Block[]> {
+  public async fetchMissingBlockCalls(
+    latestBlock: number,
+    toBlock?: number
+  ): Promise<Block[]> {
     try {
-      const to = await getLatestFinalizedBlock(this.apiPromise);
+      const to = toBlock || (await getLatestFinalizedBlock(this.apiPromise));
+
+      this.logger(
+        `Fetching missing or skipped blocks between ${
+          latestBlock + 1
+        } and ${to}`
+      );
       return await fetchRemarks(
         this.apiPromise,
         latestBlock + 1,
@@ -178,13 +197,22 @@ export class RemarkListener {
         ...this.latestBlockCallsFinalised,
       ];
 
+      // Logging
+      if (blockCalls.length > 0 && this.loggerEnabled) {
+        const blockNums = blockCalls.map((blockCall) => blockCall.block);
+        this.logger(
+          `Consolidating block range between: ${blockNums[0]} and ${
+            blockNums[blockNums.length - 1]
+          }`
+        );
+      }
+
       const remarks = getRemarksFromBlocks(blockCalls, this.prefixes);
       this.latestBlockCallsFinalised = [];
       this.missingBlockCalls = [];
-      console.log("Started consolidating at: ", this.currentBlockNum);
       const consolidatedFinal = await this.consolidateFunction(remarks);
-      console.log("Finished consolidating at: ", this.currentBlockNum);
-      await this.storageProvider.set(this.currentBlockNum);
+      const latestBlock = await this.storageProvider.get();
+      await this.storageProvider.set(this.currentBlockNum || latestBlock);
       // Fire event to a subscriber
       this.observer.next(consolidatedFinal);
     }
@@ -229,9 +257,24 @@ export class RemarkListener {
         return hexToString(call.value).includes(`::${VERSION}::`);
       });
 
+      const latestFinalisedBlockNum = header.number.toNumber();
+
       if (finalised) {
-        this.currentBlockNum = header.number.toNumber();
-        console.log("New finalised block", header.number.toNumber());
+        const latestSavedBlock = await this.storageProvider.get();
+        // Compare block sequence order to see if there's a skipped finalised block
+        if (
+          latestSavedBlock + 1 < latestFinalisedBlockNum &&
+          this.missingBlockCallsFetched
+        ) {
+          // Fetch all the missing blocks and save their remarks for next consolidation.
+          this.missingBlockCallsFetched = false;
+          this.missingBlockCalls = await this.fetchMissingBlockCalls(
+            latestSavedBlock,
+            latestFinalisedBlockNum - 1
+          );
+          this.missingBlockCallsFetched = true;
+        }
+        this.currentBlockNum = latestFinalisedBlockNum;
       }
 
       // Update local db latestBlock
@@ -241,7 +284,7 @@ export class RemarkListener {
         filteredCalls.length === 0
       ) {
         try {
-          await this.storageProvider.set(header.number.toNumber());
+          await this.storageProvider.set(latestFinalisedBlockNum);
         } catch (e: any) {
           console.error(e);
         }
@@ -249,7 +292,7 @@ export class RemarkListener {
 
       if (filteredCalls.length > 0) {
         const blockCalls: BlockCalls = {
-          block: header.number.toNumber(),
+          block: latestFinalisedBlockNum,
           calls: filteredCalls,
         };
 

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -211,8 +211,7 @@ export class RemarkListener {
       this.latestBlockCallsFinalised = [];
       this.missingBlockCalls = [];
       const consolidatedFinal = await this.consolidateFunction(remarks);
-      const latestBlock = await this.storageProvider.get();
-      await this.storageProvider.set(this.currentBlockNum || latestBlock);
+      await this.storageProvider.set(this.currentBlockNum);
       // Fire event to a subscriber
       this.observer.next(consolidatedFinal);
     }
@@ -260,9 +259,10 @@ export class RemarkListener {
       const latestFinalisedBlockNum = header.number.toNumber();
 
       if (finalised) {
-        const latestSavedBlock = await this.storageProvider.get();
+        const latestSavedBlock = this.currentBlockNum;
         // Compare block sequence order to see if there's a skipped finalised block
         if (
+          latestSavedBlock &&
           latestSavedBlock + 1 < latestFinalisedBlockNum &&
           this.missingBlockCallsFetched
         ) {


### PR DESCRIPTION
The latest substrate update does not guarantee to emit events for **every** block finalization.  Thus we should monitor incoming blocks in the listener and if any are skipped we should fetch the range for consolidation