### PR TITLE
Same block mint into+resadd

### DIFF
--- a/src/rmrk2.0.0/classes/nft.ts
+++ b/src/rmrk2.0.0/classes/nft.ts
@@ -129,6 +129,12 @@ export class NFT {
       let recipientEncoded = recipient;
       if (isValidAddressPolkadotAddress(recipient)) {
         recipientEncoded = encodeAddress(recipient, ss58Format);
+      } else {
+        const splitRecipient = String(recipientEncoded).split("-");
+        if (splitRecipient[0] === 0) {
+          splitRecipient[0] = block;
+          recipientEncoded = splitRecipient.join("-");
+        }
       }
       const obj = getRemarkData(dataString);
       return new this({

--- a/src/rmrk2.0.0/classes/resadd.ts
+++ b/src/rmrk2.0.0/classes/resadd.ts
@@ -33,7 +33,13 @@ export class Resadd {
     this.replace = replaceId;
   }
 
-  static fromRemark(remark: string): Resadd | string {
+  static fromRemark(
+    remark: string,
+    block?: number
+  ): Resadd | string {
+    if (!block) {
+      block = 0;
+    }
     try {
       validateResadd(remark);
       const [
@@ -45,7 +51,13 @@ export class Resadd {
         replaceId,
       ] = remark.split("::");
       const resourceObj: Resource = getRemarkData(resource);
-      return new this(nftId, resourceObj, replaceId);
+      let the_nftId = nftId;
+      const splitNftId = String(nftId).split("-");
+      if (splitNftId[0] === 0 && remark.block) {
+        splitNftId[0] = remark.block;
+        the_nftId = splitNftId.join("-");
+      }
+      return new this(the_nftId, resourceObj, replaceId);
     } catch (e: any) {
       console.error(e.message);
       console.log(`RESADD error: full input was ${remark}`);

--- a/src/rmrk2.0.0/tools/consolidator/consolidator.ts
+++ b/src/rmrk2.0.0/tools/consolidator/consolidator.ts
@@ -774,7 +774,7 @@ export class Consolidator {
     const invalidate = this.updateInvalidCalls(OP_TYPES.RESADD, remark).bind(
       this
     );
-    const resaddEntity = Resadd.fromRemark(remark.remark);
+    const resaddEntity = Resadd.fromRemark(remark.remark, remark.block);
     if (typeof resaddEntity === "string") {
       invalidate(
         remark.remark,


### PR DESCRIPTION
An attempt at trying to allow adding resources and minting into nfts in the same block they have been minted in by changing the block of the parent nft id to the remark block if it is 0