### PR TITLE
Check for duplicate ids

### DIFF
--- a/src/rmrk2.0.0/tools/consolidator/interactions/base.ts
+++ b/src/rmrk2.0.0/tools/consolidator/interactions/base.ts
@@ -7,5 +7,13 @@ export const getBaseFromRemark = (remark: Remark, ss58Format?: number) => {
   if (typeof base === "string") {
     throw new Error(`[${OP_TYPES.BASE}] Dead before instantiation: ${base}`);
   }
+  const part_ids = [];
+  for (let i = 0; i < base.parts.length; i++) {
+    if (part_ids.includes(base.parts[i].id)) {
+      throw new Error(`[${OP_TYPES.BASE}] Duplicate base part id found: ${base.parts[i].id}`);
+    } else {
+      part_ids.push(base.parts[i].id);
+    }
+  }
   return base;
 };

--- a/src/rmrk2.0.0/tools/consolidator/interactions/resadd.ts
+++ b/src/rmrk2.0.0/tools/consolidator/interactions/resadd.ts
@@ -30,6 +30,14 @@ export const resAddInteraction = async (
     );
   }
 
+  for (let i = 0; i < nft.resources.length; i++) {
+    if (nft.resources[i].id === resaddEntity.id) {
+      throw new Error(
+        `[${OP_TYPES.RESADD}] Attempting to add resource with already existing id ${resaddEntity.id} to NFT ${resaddEntity.nftId}`
+      );
+    }
+  }
+
   // If NFT owner is adding this resource then immediatly accept it
   const rootowner =
     nft.rootowner || (await findRealOwner(nft.owner, dbAdapter));

--- a/test/2.0.0/consolidator/__snapshots__/base.test.ts.snap
+++ b/test/2.0.0/consolidator/__snapshots__/base.test.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`rmrk2.0.0 Consolidator: CREATE BASE Should prevent creating a Base with duplicate part ids 1`] = `
+Object {
+  "bases": Object {},
+  "collections": Object {},
+  "invalid": Array [
+    Object {
+      "block": 2,
+      "caller": "HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F",
+      "message": "[BASE] Duplicate base part id found: background",
+      "object_id": "RMRK::BASE::2.0.0::{\\"symbol\\"%3A\\"KBASE777\\"%2C\\"type\\"%3A\\"svg\\"%2C\\"issuer\\"%3A\\"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY\\"%2C\\"parts\\"%3A[{\\"id\\"%3A\\"background\\"%2C\\"type\\"%3A\\"slot\\"%2C\\"equippable\\"%3A[]%2C\\"z\\"%3A0}%2C{\\"id\\"%3A\\"background\\"%2C\\"type\\"%3A\\"slot\\"%2C\\"equippable\\"%3A[\\"d43593c715a56da27d-KANARIABIRDS\\"]%2C\\"z\\"%3A1}]%2C\\"themes\\"%3A{\\"themeOne\\"%3A{\\"_inherit\\"%3Atrue%2C\\"primary\\"%3A\\"%23fff\\"}}}",
+      "op_type": "BASE",
+    },
+  ],
+  "nfts": Object {},
+}
+`;
+
 exports[`rmrk2.0.0 Consolidator: CREATE BASE should correctly create a Base 1`] = `
 Object {
   "bases": Object {

--- a/test/2.0.0/consolidator/base.test.ts
+++ b/test/2.0.0/consolidator/base.test.ts
@@ -1,6 +1,7 @@
 import { Consolidator } from "../../../src/rmrk2.0.0";
 import {
   createBaseMock,
+  createBaseMock2,
   getBlockCallsMock,
   getRemarksFromBlocksMock,
 } from "../mocks";
@@ -14,6 +15,14 @@ describe("rmrk2.0.0 Consolidator: CREATE BASE", () => {
   it("should correctly create a Base", async () => {
     const remarks = getRemarksFromBlocksMock(
       getBlockCallsMock(createBaseMock().base())
+    );
+    const consolidator = new Consolidator();
+    expect(await consolidator.consolidate(remarks)).toMatchSnapshot();
+  });
+
+  it("Should prevent creating a Base with duplicate part ids", async () => {
+    const remarks = getRemarksFromBlocksMock(
+      getBlockCallsMock(createBaseMock2().base())
     );
     const consolidator = new Consolidator();
     expect(await consolidator.consolidate(remarks)).toMatchSnapshot();

--- a/test/2.0.0/consolidator/resadd.test.ts
+++ b/test/2.0.0/consolidator/resadd.test.ts
@@ -96,4 +96,29 @@ describe("rmrk2.0.0 Consolidator: RESADD", () => {
       consolidatedResult.nfts[mintNftMock(3).getId()].resources[0].pending
     ).toBeTruthy();
   });
+
+  it("Should prevent adding a resource with already existing id to an NFT", async () => {
+    const remarks = getRemarksFromBlocksMock([
+      ...getSetupRemarks(),
+      ...getBlockCallsMock(
+        mintNftMock(3).resadd({ metadata: "ipfs://ipfs/123", id: "Test" })
+      ),
+      ...getBlockCallsMock(
+        mintNftMock(3).resadd({ metadata: "ipfs://ipfs/456", id: "Test" })
+      ),
+    ]);
+    const consolidator = new Consolidator();
+    const consolidatedResult = await consolidator.consolidate(remarks);
+    expect(consolidatedResult.nfts[mintNftMock(3).getId()].resources.length).toEqual(1);
+    expect(consolidatedResult.nfts[mintNftMock(3).getId()].resources[0].metadata).toEqual(
+      "ipfs://ipfs/123"
+    );
+    expect(consolidatedResult.nfts[mintNftMock(3).getId()].priority[0]).toEqual(
+      consolidatedResult.nfts[mintNftMock(3).getId()].resources[0].id
+    );
+    expect(consolidatedResult.nfts[mintNftMock(3).getId()].priority.length).toEqual(1);
+    expect(consolidatedResult.invalid[0].message).toEqual(
+      "[RESADD] Attempting to add resource with already existing id Test to NFT 3-d43593c715a56da27d-KANARIABIRDS-KANR-00000777"
+    );
+  });
 });

--- a/test/2.0.0/mocks.ts
+++ b/test/2.0.0/mocks.ts
@@ -128,6 +128,34 @@ export const createBaseMock = (block?: number): Base =>
     { themeOne: { _inherit: true, primary: "#fff" } }
   );
 
+export const createBaseMock2 = (block?: number): Base =>
+  new Base(
+    block || 0,
+    "KBASE777",
+    getAliceKey().address,
+    "svg",
+    [
+      {
+        id: "background",
+        type: "slot",
+        equippable: [],
+        z: 0,
+      },
+      {
+        id: "background",
+        type: "slot",
+        equippable: [
+          Collection.generateId(
+            u8aToHex(getAliceKey().publicKey),
+            "KANARIABIRDS"
+          ),
+        ],
+        z: 1,
+      },
+    ],
+    { themeOne: { _inherit: true, primary: "#fff" } }
+  );
+
 export const getBlockCallsMock = (
   remark: string,
   caller: string = getAliceKey().address,


### PR DESCRIPTION
Checks for and invalidates bases with duplicate base part ids like mentioned in https://github.com/rmrk-team/rmrk-tools/issues/104 and resadds with ids already present in the nfts resource list