### PR TITLE
Decode send recipient nft

### DIFF
--- a/src/rmrk2.0.0/tools/validate-remark.ts
+++ b/src/rmrk2.0.0/tools/validate-remark.ts
@@ -307,6 +307,7 @@ export const validateSend = (remark: string): any => {
 
   try {
     validateRemarkBase(remark, OP_TYPES.SEND);
+    id = decodeURIComponent(id);
     if (!isValidAddressPolkadotAddress(recipient)) {
       recipient = decodeURIComponent(recipient);
     }

--- a/src/rmrk2.0.0/tools/validate-remark.ts
+++ b/src/rmrk2.0.0/tools/validate-remark.ts
@@ -18,6 +18,7 @@ import {
   boolean,
 } from "superstruct";
 import { getRemarkData } from "./utils";
+import { isValidAddressPolkadotAddress } from "./consolidator/utils";
 import { collectionRegexPattern } from "../classes/equippable";
 import { PropertiesStruct } from "./validate-metadata";
 import { IProperties, IRoyaltyAttribute } from "./types";
@@ -302,14 +303,12 @@ export const validateSetAttribute = (remark: string): any => {
 
 export const validateSend = (remark: string): any => {
   // With array destructuring it's important to not remove unused destructured variables, as order is important
-  const [_prefix, _op_type, _version, id, recipient] = remark.split("::");
+  let [_prefix, _op_type, _version, id, recipient] = remark.split("::");
 
   try {
     validateRemarkBase(remark, OP_TYPES.SEND);
-    if (/\s/g.test(recipient)) {
-      throw new Error(
-        "Invalid remark - No whitespaces are allowed in recipient"
-      );
+    if (!isValidAddressPolkadotAddress(recipient)) {
+      recipient = decodeURIComponent(recipient);
     }
     return assert({ id, recipient }, SENDStruct);
   } catch (error: any) {

--- a/src/rmrk2.0.0/tools/validate-remark.ts
+++ b/src/rmrk2.0.0/tools/validate-remark.ts
@@ -307,11 +307,10 @@ export const validateSend = (remark: string): any => {
 
   try {
     validateRemarkBase(remark, OP_TYPES.SEND);
-    id = decodeURIComponent(id);
     if (!isValidAddressPolkadotAddress(recipient)) {
       recipient = decodeURIComponent(recipient);
     }
-    return assert({ id, recipient }, SENDStruct);
+    return assert({ decodeURIComponent(id), recipient }, SENDStruct);
   } catch (error: any) {
     throw new Error(
       error?.message || "Something went wrong during remark validation"


### PR DESCRIPTION
Removing error thrown for spaces in nft ids and decoding the recipient if it is an nft to allow sending to nfts with spaces in the id